### PR TITLE
fix masked urls

### DIFF
--- a/plugins/module_utils/healthchecksio.py
+++ b/plugins/module_utils/healthchecksio.py
@@ -133,7 +133,6 @@ class HealthchecksioHelper:
                     ],
                 ),
                 required=False,
-                no_log=True,
                 default="https://healthchecks.io"
             ),
         )


### PR DESCRIPTION
URLs get masked using self-hosted branch, even the ping_url is masked if using non-default API base URL. This doesn't happen on main. This PR fixes the issue.

Result:
```
    "pause_url": "********/api/v1/checks/<UUID>/pause",
    "ping_url": "https://hc-ping.com/<UUID>",
    "resume_url": "********/api/v1/checks/<UUID>/resume",
    "update_url": "********/api/v1/checks/<UUID>"
```

Expected result:
```
    "pause_url": "https://healthchecks.io/api/v1/checks/<UUID>/pause",
    "ping_url": "https://hc-ping.com/<UUID>",
    "resume_url": "https://healthchecks.io/api/v1/checks/<UUID>/resume",
    "update_url": "https://healthchecks.io/api/v1/checks/<UUID>"
```

The results can be verified with a simple test playbook
```
---
- name: Testing
  hosts: localhost
  connection: local
  gather_facts: false
  become: false
  tasks:
    - name: Create a check named "test hourly"
      community.healthchecksio.checks:
        state: present
        name: "test hourly"
        unique: ["name"]
        tags: ["test", "hourly"]
        desc: "my hourly test check"
        schedule: "0 * * * *"
        tz: UTC
      register: hc

    - name: Print response
      ansible.builtin.debug:
        var: hc
```